### PR TITLE
Added IsHierarchical property to XrmFakedRelationship to support AboveOrEqual condition expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2.5.1]
+
+### Added
+
+- Added the IsHierarchical property to XrmFakedRelationship in order to support AboveOrEqual condition expressions in FakeXrmEasy.Core
+
 ## [2.5.0]
 
 ### Changed

--- a/src/FakeXrmEasy.Abstractions/FakeXrmEasy.Abstractions.csproj
+++ b/src/FakeXrmEasy.Abstractions/FakeXrmEasy.Abstractions.csproj
@@ -7,7 +7,7 @@
     <TargetFrameworks Condition="'$(Configuration)'=='FAKE_XRM_EASY_2013'">net452</TargetFrameworks>
     <TargetFrameworks Condition="'$(Configuration)'=='FAKE_XRM_EASY'">net452</TargetFrameworks>
     <PackageId>FakeXrmEasy.Abstractions</PackageId>
-    <VersionPrefix>2.5.0</VersionPrefix>
+    <VersionPrefix>2.5.1</VersionPrefix>
     <Authors>Jordi Montaña</Authors>
     <Company>Dynamics Value</Company>
     <Title>FakeXrmEasy Abstractions</Title>

--- a/src/FakeXrmEasy.Abstractions/XrmFakedRelationship.cs
+++ b/src/FakeXrmEasy.Abstractions/XrmFakedRelationship.cs
@@ -62,6 +62,11 @@ namespace FakeXrmEasy.Abstractions
         }
 
         /// <summary>
+        /// Specifies if relationship is Hierachical or not.
+        /// </summary>
+        public bool IsHierarchical { get; set; }
+
+        /// <summary>
         /// Relationship Type
         /// </summary>
         public enum FakeRelationshipType
@@ -87,6 +92,7 @@ namespace FakeXrmEasy.Abstractions
         public XrmFakedRelationship()
         {
             RelationshipType = FakeRelationshipType.ManyToMany;
+            IsHierarchical = false;
         }
 
         /// <summary>
@@ -105,6 +111,7 @@ namespace FakeXrmEasy.Abstractions
             Entity1LogicalName = entity1LogicalName;
             Entity2LogicalName = entity2LogicalName;
             RelationshipType = FakeRelationshipType.ManyToMany;
+            IsHierarchical = false;
         }
 
         /// <summary>
@@ -114,13 +121,15 @@ namespace FakeXrmEasy.Abstractions
         /// <param name="entity2Attribute"></param>
         /// <param name="entity1LogicalName"></param>
         /// <param name="entity2LogicalName"></param>
-        public XrmFakedRelationship(string entity1Attribute, string entity2Attribute, string entity1LogicalName, string entity2LogicalName)
+        /// <param name="isHierarchical"></param>
+        public XrmFakedRelationship(string entity1Attribute, string entity2Attribute, string entity1LogicalName, string entity2LogicalName, bool isHierarchical = false)
         {
             Entity1Attribute = entity1Attribute;
             Entity2Attribute = entity2Attribute;
             Entity1LogicalName = entity1LogicalName;
             Entity2LogicalName = entity2LogicalName;
             RelationshipType = FakeRelationshipType.OneToMany;
-        }
+            IsHierarchical = isHierarchical;
+        }        
     }
 }

--- a/tests/FakeXrmEasy.Abstractions.Tests/FakeXrmEasy.Abstractions.Tests.csproj
+++ b/tests/FakeXrmEasy.Abstractions.Tests/FakeXrmEasy.Abstractions.Tests.csproj
@@ -10,7 +10,7 @@
     <IsPackable>true</IsPackable>
 
     <PackageId>FakeXrmEasy.AbstractionsTests</PackageId>
-    <VersionPrefix>2.5.0</VersionPrefix>
+    <VersionPrefix>2.5.1</VersionPrefix>
     <Authors>Jordi Montaña</Authors>
     <Company>Dynamics Value S.L.</Company>
     <Title>FakeXrmEasy Abstractions Tests</Title>
@@ -71,22 +71,22 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(PackTests)' == 'true' And '$(Configuration)'=='FAKE_XRM_EASY'">
-    <PackageReference Include="FakeXrmEasy.Abstractions.v2011" Version="2.5.0-*" />
+    <PackageReference Include="FakeXrmEasy.Abstractions.v2011" Version="2.5.1-*" />
   </ItemGroup>
   <ItemGroup Condition="'$(PackTests)' == 'true' And '$(Configuration)'=='FAKE_XRM_EASY_2013'">
-    <PackageReference Include="FakeXrmEasy.Abstractions.v2013" Version="2.5.0-*" />
+    <PackageReference Include="FakeXrmEasy.Abstractions.v2013" Version="2.5.1-*" />
   </ItemGroup>
   <ItemGroup Condition="'$(PackTests)' == 'true' And '$(Configuration)'=='FAKE_XRM_EASY_2015'">
-    <PackageReference Include="FakeXrmEasy.Abstractions.v2015" Version="2.5.0-*" />
+    <PackageReference Include="FakeXrmEasy.Abstractions.v2015" Version="2.5.1-*" />
   </ItemGroup>
   <ItemGroup Condition="'$(PackTests)' == 'true' And '$(Configuration)'=='FAKE_XRM_EASY_2016'">
-    <PackageReference Include="FakeXrmEasy.Abstractions.v2016" Version="2.5.0-*" />
+    <PackageReference Include="FakeXrmEasy.Abstractions.v2016" Version="2.5.1-*" />
   </ItemGroup>
   <ItemGroup Condition="'$(PackTests)' == 'true' And '$(Configuration)'=='FAKE_XRM_EASY_365'">
-    <PackageReference Include="FakeXrmEasy.Abstractions.v365" Version="2.5.0-*" />
+    <PackageReference Include="FakeXrmEasy.Abstractions.v365" Version="2.5.1-*" />
   </ItemGroup>
   <ItemGroup Condition="'$(PackTests)' == 'true' And '$(Configuration)'=='FAKE_XRM_EASY_9'">
-    <PackageReference Include="FakeXrmEasy.Abstractions.v9" Version="2.5.0-*" />
+    <PackageReference Include="FakeXrmEasy.Abstractions.v9" Version="2.5.1-*" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Plugins\" />


### PR DESCRIPTION
Added IsHierarchical property to XrmFakedRelationship to support AboveOrEqual condition expressions

**What issue does this PR address?**
To support AboveOrEqual condition expressions in a Query Expression you need to determine which relations are hierarchical and can be use to determine the hierarchy of an entity.

This PR only adds the IsHierarchical property (like the metadata of an Xrm relationship has as wel) and the implementation of AboveOrEqual will be in the fake-xrm-easy-core repository. 

**Important: Any code or remarks in your Pull Request are under the following terms:**

You acknowledge and agree that by submitting a request or making any code, comment, remark, feedback, enhancements, or modifications proposed or suggested by You in your pull request, You are deemed to accept the terms of our [Contributor License Agreement (CLA)](https://github.com/DynamicsValue/licence-agreements/blob/main/FakeXrmEasy/CLA.md) and that the CLA document is fully enforceable and effective for You. 

